### PR TITLE
Don’t rAF with 

### DIFF
--- a/js/element-cache.tsx
+++ b/js/element-cache.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+
+interface Props {
+  cacheName: string;
+}
+
+interface State {}
+
+const cache = new Map();
+export default class ElementCache extends React.Component<Props, State> {
+  render() {
+    return (
+      <React.Fragment>
+        {cache.has(this.props.cacheName)
+          ? cache.get(this.props.cacheName)
+          : this.props.children}
+      </React.Fragment>
+    );
+  }
+
+  componentDidUpdate() {
+    if (cache.has(this.props.cacheName)) {
+      return;
+    }
+    cache.set(this.props.cacheName, this.props.children);
+  }
+}

--- a/js/main.tsx
+++ b/js/main.tsx
@@ -1,11 +1,8 @@
 import React from "react";
 import ReactDOM from "react-dom";
 
-import "./bootstrap/less/bootstrap.less"
+import "./bootstrap/less/bootstrap.less";
 
 import { MyComponent } from "./my-component";
 
-ReactDOM.render(
-    <MyComponent/>,
-    document.getElementById("root")
-);
+ReactDOM.render(<MyComponent />, document.getElementById("root"));

--- a/js/my-component.tsx
+++ b/js/my-component.tsx
@@ -45,27 +45,12 @@ class MyComponent extends React.Component<Props, State> {
   componentDidMount() {
     const canvasEl = document.getElementById(CANVAS_ID)!;
     this.setState({ canvasEl });
-    // this.startUpdateElementPositionLoop();
     this.registerFscreenCallbacks();
   }
 
   componentWillUnmount() {
     this.unregisterFscreenCallbacks();
   }
-
-  // tslint:disable-next-line:no-unused
-  // componentDidUpdate(prevProps: Props, prevState: State) {
-  //     if (this.state.targetId !== prevState.targetId) {
-  //         this.updateTarget();
-  //     }
-  // }
-
-  // private updateTarget = () => {
-  //     const target = document.getElementById(this.state.targetId);
-  //     if (target) {
-  //         this.setState({ target });
-  //     }
-  // };
 
   private showModal = () => {
     this.setState({
@@ -80,33 +65,6 @@ class MyComponent extends React.Component<Props, State> {
       canvasMode: CanvasMode.EMBED
     });
   };
-
-  // private mountSource = (src: HTMLDivElement) => {
-  //     this.src = src;
-  // };
-
-  // private startUpdateElementPositionLoop = () => {
-  //     if (!this.renderActive) {
-  //         this.renderActive = true;
-  //         this.updateElementPositionLoop();
-  //     }
-  // };
-
-  // private stopUpdateElementPositionLoop = () => {
-  //     if (this.renderActive) {
-  //         this.renderActive = false;
-  //         if (this.animationFrameId) {
-  //             window.cancelAnimationFrame(this.animationFrameId);
-  //         }
-  //     }
-  // };
-
-  // private updateElementPositionLoop = () => {
-  //     this.fixRenderElementPosition();
-  //     if (this.renderActive) {
-  //         this.animationFrameId = window.requestAnimationFrame(this.updateElementPositionLoop);
-  //     }
-  // };
 
   private enterFullscreen = () => {
     this.setState(
@@ -132,49 +90,6 @@ class MyComponent extends React.Component<Props, State> {
   private unregisterFscreenCallbacks = () => {
     fscreen.removeEventListener("fullscreenchange", this.onFullScreenChange);
   };
-
-  // private fixRenderElementPosition = () => {
-  //     const { target, targetId } = this.state;
-  //     const { src } = this;
-
-  //     if (target && src) {
-  //         const targetPos = target.getBoundingClientRect();
-  //         switch (targetId) {
-  //             case "target1": {
-  //                 const top = totalOffsetTop(target);
-  //                 const left = totalOffsetLeft(target);
-  //                 src.style.top = `${top}px`;
-  //                 src.style.left = `${left}px`;
-  //                 src.style.width = `${targetPos.width}px`;
-  //                 src.style.height = `${targetPos.height}px`;
-  //                 break;
-  //             }
-  //             case "target2": {
-  //                 const sourcePos = src.getBoundingClientRect();
-  //                 if (targetPos.top !== sourcePos.top) {
-  //                     src.style.top = `${targetPos.top}px`;
-  //                 }
-  //                 if (targetPos.left !== sourcePos.left) {
-  //                     src.style.left = `${targetPos.left}px`;
-  //                 }
-  //                 if (targetPos.width !== sourcePos.width) {
-  //                     src.style.width = `${targetPos.width}px`;
-  //                 }
-  //                 if (targetPos.height !== sourcePos.height) {
-  //                     src.style.height = `${targetPos.height}px`;
-  //                 }
-  //                 break;
-  //             }
-  //             case "fullscreen": {
-  //                 src.style.top = "0px";
-  //                 src.style.left = "0px";
-  //                 src.style.width = `${targetPos.width}px`;
-  //                 src.style.height = `${targetPos.height}px`;
-  //                 break;
-  //             }
-  //         }
-  //     }
-  // };
 
   private onFullScreenChange = () => {
     const isFullScreen = fscreen.fullscreenElement !== null;

--- a/js/my-component.tsx
+++ b/js/my-component.tsx
@@ -1,308 +1,327 @@
 import React from "react";
 import {
-    Button,
-    Col,
-    Grid, Modal,
-    Nav,
-    Navbar, NavItem,
+  Button,
+  Col,
+  Grid,
+  Modal,
+  Nav,
+  Navbar,
+  NavItem
 } from "react-bootstrap";
-import * as Row from "react-bootstrap/lib/Row";
 import fscreen from "fscreen";
+import * as Row from "react-bootstrap/lib/Row";
 import style from "./my-component.module.less";
 
+import ElementCache from "./element-cache";
 interface Props {
-    // Empty
+  // Empty
+}
+
+enum CanvasMode {
+  EMBED,
+  MODAL,
+  FULLSCREEN
 }
 
 interface State {
-    showModal: boolean;
-    targetId: string;
-    target: HTMLElement | null;
+  showModal: boolean;
+  canvasMode: CanvasMode;
+  canvasEl?: HTMLElement;
 }
 
-function totalOffsetTop(element: HTMLElement): number {
-    let el: Element | undefined = element;
-    let offsetTop = 0;
-    while (el instanceof HTMLElement) {
-        offsetTop += el.offsetTop;
-        el = el.offsetParent;
-    }
-    return offsetTop;
-}
-
-function totalOffsetLeft(element: HTMLElement): number {
-    let el: Element | undefined = element;
-    let offsetLeft = 0;
-    while (el instanceof HTMLElement) {
-        offsetLeft += el.offsetLeft;
-        el = el.offsetParent;
-    }
-    return offsetLeft;
-}
+const CANVAS_ID = "canvasEl";
 
 class MyComponent extends React.Component<Props, State> {
+  private fullscreenDiv?: HTMLDivElement;
 
-    private renderActive = false;
+  constructor(props: Props) {
+    super(props);
+    this.state = {
+      showModal: false,
+      canvasMode: CanvasMode.EMBED
+    };
+  }
 
-    private src?: HTMLDivElement;
+  componentDidMount() {
+    const canvasEl = document.getElementById(CANVAS_ID)!;
+    this.setState({ canvasEl });
+    // this.startUpdateElementPositionLoop();
+    this.registerFscreenCallbacks();
+  }
 
-    private fullscreenDiv?: HTMLDivElement;
+  componentWillUnmount() {
+    this.unregisterFscreenCallbacks();
+  }
 
-    private animationFrameId?: number;
+  // tslint:disable-next-line:no-unused
+  // componentDidUpdate(prevProps: Props, prevState: State) {
+  //     if (this.state.targetId !== prevState.targetId) {
+  //         this.updateTarget();
+  //     }
+  // }
 
-    constructor(props: Props) {
-        super(props);
-        this.state = {
-            showModal: false,
-            targetId: "target1",
-            // tslint:disable-next-line:no-null-keyword
-            target: null,
-        };
+  // private updateTarget = () => {
+  //     const target = document.getElementById(this.state.targetId);
+  //     if (target) {
+  //         this.setState({ target });
+  //     }
+  // };
+
+  private showModal = () => {
+    this.setState({
+      showModal: true,
+      canvasMode: CanvasMode.MODAL
+    });
+  };
+
+  private onHideModal = () => {
+    this.setState({
+      showModal: false,
+      canvasMode: CanvasMode.EMBED
+    });
+  };
+
+  // private mountSource = (src: HTMLDivElement) => {
+  //     this.src = src;
+  // };
+
+  // private startUpdateElementPositionLoop = () => {
+  //     if (!this.renderActive) {
+  //         this.renderActive = true;
+  //         this.updateElementPositionLoop();
+  //     }
+  // };
+
+  // private stopUpdateElementPositionLoop = () => {
+  //     if (this.renderActive) {
+  //         this.renderActive = false;
+  //         if (this.animationFrameId) {
+  //             window.cancelAnimationFrame(this.animationFrameId);
+  //         }
+  //     }
+  // };
+
+  // private updateElementPositionLoop = () => {
+  //     this.fixRenderElementPosition();
+  //     if (this.renderActive) {
+  //         this.animationFrameId = window.requestAnimationFrame(this.updateElementPositionLoop);
+  //     }
+  // };
+
+  private enterFullscreen = () => {
+    this.setState(
+      {
+        canvasMode: CanvasMode.FULLSCREEN
+      },
+      () => {
+        if (this.fullscreenDiv) {
+          fscreen.requestFullscreen(this.fullscreenDiv);
+        }
+      }
+    );
+  };
+
+  private mountFullscreenDiv = (fullscreenDiv: HTMLDivElement) => {
+    this.fullscreenDiv = fullscreenDiv;
+  };
+
+  private registerFscreenCallbacks = () => {
+    fscreen.addEventListener("fullscreenchange", this.onFullScreenChange);
+  };
+
+  private unregisterFscreenCallbacks = () => {
+    fscreen.removeEventListener("fullscreenchange", this.onFullScreenChange);
+  };
+
+  // private fixRenderElementPosition = () => {
+  //     const { target, targetId } = this.state;
+  //     const { src } = this;
+
+  //     if (target && src) {
+  //         const targetPos = target.getBoundingClientRect();
+  //         switch (targetId) {
+  //             case "target1": {
+  //                 const top = totalOffsetTop(target);
+  //                 const left = totalOffsetLeft(target);
+  //                 src.style.top = `${top}px`;
+  //                 src.style.left = `${left}px`;
+  //                 src.style.width = `${targetPos.width}px`;
+  //                 src.style.height = `${targetPos.height}px`;
+  //                 break;
+  //             }
+  //             case "target2": {
+  //                 const sourcePos = src.getBoundingClientRect();
+  //                 if (targetPos.top !== sourcePos.top) {
+  //                     src.style.top = `${targetPos.top}px`;
+  //                 }
+  //                 if (targetPos.left !== sourcePos.left) {
+  //                     src.style.left = `${targetPos.left}px`;
+  //                 }
+  //                 if (targetPos.width !== sourcePos.width) {
+  //                     src.style.width = `${targetPos.width}px`;
+  //                 }
+  //                 if (targetPos.height !== sourcePos.height) {
+  //                     src.style.height = `${targetPos.height}px`;
+  //                 }
+  //                 break;
+  //             }
+  //             case "fullscreen": {
+  //                 src.style.top = "0px";
+  //                 src.style.left = "0px";
+  //                 src.style.width = `${targetPos.width}px`;
+  //                 src.style.height = `${targetPos.height}px`;
+  //                 break;
+  //             }
+  //         }
+  //     }
+  // };
+
+  private onFullScreenChange = () => {
+    const isFullScreen = fscreen.fullscreenElement !== null;
+    if (!isFullScreen) {
+      this.setState({ canvasMode: CanvasMode.EMBED });
     }
+  };
 
-    componentDidMount() {
-        const target = document.getElementById(this.state.targetId);
-        this.setState({ target });
-        this.startUpdateElementPositionLoop();
-        this.registerFscreenCallbacks();
-    }
-
-    componentWillUnmount() {
-        this.stopUpdateElementPositionLoop();
-        this.unregisterFscreenCallbacks();
-    }
-
-    // tslint:disable-next-line:no-unused
-    componentDidUpdate(prevProps: Props, prevState: State) {
-        if (this.state.targetId !== prevState.targetId) {
-            this.updateTarget();
-        }
-    }
-
-    private updateTarget = () => {
-        const target = document.getElementById(this.state.targetId);
-        if (target) {
-            this.setState({ target });
-        }
-    };
-
-    private showModal = () => {
-        this.setState({
-            showModal: true,
-            targetId: "target2",
-        });
-    };
-
-    private onHideModal = () => {
-        this.setState({
-            showModal: false,
-            targetId: "target1",
-        });
-    };
-
-    private mountSource = (src: HTMLDivElement) => {
-        this.src = src;
-    };
-
-    private startUpdateElementPositionLoop = () => {
-        if (!this.renderActive) {
-            this.renderActive = true;
-            this.updateElementPositionLoop();
-        }
-    };
-
-    private stopUpdateElementPositionLoop = () => {
-        if (this.renderActive) {
-            this.renderActive = false;
-            if (this.animationFrameId) {
-                window.cancelAnimationFrame(this.animationFrameId);
-            }
-        }
-    };
-
-    private updateElementPositionLoop = () => {
-        this.fixRenderElementPosition();
-        if (this.renderActive) {
-            this.animationFrameId = window.requestAnimationFrame(this.updateElementPositionLoop);
-        }
-    };
-
-    private enterFullscreen = () => {
-        this.setState({
-            targetId: "fullscreen",
-        }, () => {
-            if (this.fullscreenDiv) {
-                fscreen.requestFullscreen(this.fullscreenDiv);
-            }
-        });
-    };
-
-    private mountFullscreenDiv = (fullscreenDiv: HTMLDivElement) => {
-        this.fullscreenDiv = fullscreenDiv;
-    };
-
-    private registerFscreenCallbacks = () => {
-        fscreen.addEventListener("fullscreenchange", this.onFullScreenChange);
-    };
-
-    private unregisterFscreenCallbacks = () => {
-        fscreen.removeEventListener("fullscreenchange", this.onFullScreenChange);
-    };
-
-    private fixRenderElementPosition = () => {
-        const { target, targetId } = this.state;
-        const { src } = this;
-
-        if (target && src) {
-            const targetPos = target.getBoundingClientRect();
-            switch (targetId) {
-                case "target1": {
-                    const top = totalOffsetTop(target);
-                    const left = totalOffsetLeft(target);
-                    src.style.top = `${top}px`;
-                    src.style.left = `${left}px`;
-                    src.style.width = `${targetPos.width}px`;
-                    src.style.height = `${targetPos.height}px`;
-                    break;
-                }
-                case "target2": {
-                    const sourcePos = src.getBoundingClientRect();
-                    if (targetPos.top !== sourcePos.top) {
-                        src.style.top = `${targetPos.top}px`;
-                    }
-                    if (targetPos.left !== sourcePos.left) {
-                        src.style.left = `${targetPos.left}px`;
-                    }
-                    if (targetPos.width !== sourcePos.width) {
-                        src.style.width = `${targetPos.width}px`;
-                    }
-                    if (targetPos.height !== sourcePos.height) {
-                        src.style.height = `${targetPos.height}px`;
-                    }
-                    break;
-                }
-                case "fullscreen": {
-                    src.style.top = "0px";
-                    src.style.left = "0px";
-                    src.style.width = `${targetPos.width}px`;
-                    src.style.height = `${targetPos.height}px`;
-                    break;
-                }
-            }
-        }
-    };
-
-    private onFullScreenChange = () => {
-        const isFullScreen = (fscreen.fullscreenElement !== null);
-        if (!isFullScreen) {
-            this.setState({ targetId: "target1" });
-        }
-    };
-
-    render() {
-        let display = "none";
-        let zIndex: ("auto" | number) = "auto";
-        let position: "fixed" | "absolute" = "absolute";
-
-        if (this.src && this.state.target) {
-            display = "block";
-
-            if (this.state.targetId === "target2") {
-                zIndex = 2001;
-                position = "fixed";
-            }
-        }
-
-        return (
-            <React.Fragment>
-                <Grid>
-                    <Navbar collapseOnSelect>
-                        <Navbar.Header>
-                            <Navbar.Brand>
-                                Title
-                            </Navbar.Brand>
-                            <Navbar.Toggle />
-                        </Navbar.Header>
-                        <Navbar.Collapse>
-                            <Nav>
-                                <NavItem>
-                                    Item 1
-                                </NavItem>
-                            </Nav>
-                        </Navbar.Collapse>
-                    </Navbar>
-                    <Row>
-                        <Col xs={12}>
-                            <div id="target1" style={{ width: "100%", height: "20vh", background: "red" }}/>
-
-                            <Button
-                                onClick={this.showModal}
-                            >
-                                Show modal
-                            </Button>
-                            <Button
-                                onClick={this.enterFullscreen}
-                            >
-                                Enter fullscreen
-                            </Button>
-
-                            <p>
-                                Imagine a canvas that can be placed in multiple locations, and is therefore not suitable as
-                                a child of any specific DOM node, but rather lives its own life in the "root" of the react DOM.
-                            </p>
-
-                            <p>
-                                Try using this site in "mobile" mode and expand the menu - yet another case that is tricky
-                                even with absolute positioning, without using a requestAnimationFrame loop.
-                            </p>
-
-                            <p>
-                                Using such loops to position elements that render OpenGL stuff or videos inevitably leads
-                                to glitches and / or bad performance.
-                            </p>
-
-                            <div style={{ height: "150vh", background: "grey" }}>
-                                There is a lot of content on this page.
-                            </div>
-                        </Col>
-                    </Row>
-                </Grid>
-                <Modal show={this.state.showModal} onHide={this.onHideModal}>
-                    <Modal.Header closeButton>
-                        A modal
-                    </Modal.Header>
-                    <Modal.Body>
-                        <div
-                            id="target2"
-                            ref={this.updateTarget}
-                            style={{ width: "100%", height: "50vh", background: "red" }}
-                        />
-
-                        <p>
-                            This bootstrap modal has fixed positioning externally, and we can't position the canvas
-                            properly without using a loop.
-                        </p>
-
-                        <div style={{ height: "150vh", background: "grey" }}>
-                            This modal has a lot of content and is scrollable.
-                        </div>
-
-                    </Modal.Body>
-                </Modal>
-                <div id="fullscreen" ref={this.mountFullscreenDiv} className={style.fullScreenWrap}>
+  render() {
+    return (
+      <React.Fragment>
+        <Grid>
+          <Navbar collapseOnSelect>
+            <Navbar.Header>
+              <Navbar.Brand>Title</Navbar.Brand>
+              <Navbar.Toggle />
+            </Navbar.Header>
+            <Navbar.Collapse>
+              <Nav>
+                <NavItem>Item 1</NavItem>
+              </Nav>
+            </Navbar.Collapse>
+          </Navbar>
+          <Row>
+            <Col xs={12}>
+              <div
+                id="target1"
+                style={{
+                  width: "100%",
+                  height: "20vh",
+                  background: "red",
+                  position: "relative"
+                }}
+              >
+                {this.state.canvasMode === CanvasMode.EMBED ? (
+                  <ElementCache cacheName="canvas">
                     <div
-                        ref={this.mountSource}
-                        className={`${style.surface} ${style.sourceCanvas}`}
-                        style={{ display, zIndex, position, background: "blue" }}
+                      className={`${style.surface} ${style.sourceCanvas}`}
+                      style={{
+                        background: "blue",
+                        position: "absolute",
+                        left: 0,
+                        right: 0,
+                        top: 0,
+                        bottom: 0
+                      }}
                     >
-                        I'm a "Canvas"
+                      I'm a "Canvas"
                     </div>
-                </div>
-            </React.Fragment>
-        );
-    }
+                  </ElementCache>
+                ) : null}
+              </div>
+
+              <Button onClick={this.showModal}>Show modal</Button>
+              <Button onClick={this.enterFullscreen}>Enter fullscreen</Button>
+
+              <p>
+                Imagine a canvas that can be placed in multiple locations, and
+                is therefore not suitable as a child of any specific DOM node,
+                but rather lives its own life in the "root" of the react DOM.
+              </p>
+
+              <p>
+                Try using this site in "mobile" mode and expand the menu - yet
+                another case that is tricky even with absolute positioning,
+                without using a requestAnimationFrame loop.
+              </p>
+
+              <p>
+                Using such loops to position elements that render OpenGL stuff
+                or videos inevitably leads to glitches and / or bad performance.
+              </p>
+
+              <div style={{ height: "150vh", background: "grey" }}>
+                There is a lot of content on this page.
+              </div>
+            </Col>
+          </Row>
+        </Grid>
+        <Modal show={this.state.showModal} onHide={this.onHideModal}>
+          <Modal.Header closeButton>A modal</Modal.Header>
+          <Modal.Body>
+            <div
+              id="target2"
+              style={{
+                width: "100%",
+                height: "50vh",
+                background: "red",
+                position: "relative"
+              }}
+            >
+              {this.state.canvasMode === CanvasMode.MODAL ? (
+                <ElementCache cacheName="canvas">
+                  <div
+                    className={`${style.surface} ${style.sourceCanvas}`}
+                    style={{
+                      background: "green",
+                      position: "absolute",
+                      left: 0,
+                      right: 0,
+                      top: 0,
+                      bottom: 0
+                    }}
+                  >
+                    I'm a "Canvas"
+                  </div>
+                </ElementCache>
+              ) : null}
+            </div>
+
+            <p>
+              This bootstrap modal has fixed positioning externally, and we
+              can't position the canvas properly without using a loop.
+            </p>
+
+            <div style={{ height: "150vh", background: "grey" }}>
+              This modal has a lot of content and is scrollable.
+            </div>
+          </Modal.Body>
+        </Modal>
+        <div
+          id="fullscreen"
+          ref={this.mountFullscreenDiv}
+          className={style.fullScreenWrap}
+          style={{ position: "relative" }}
+        >
+          {this.state.canvasMode === CanvasMode.FULLSCREEN ? (
+            <ElementCache cacheName="canvas">
+              <div
+                className={`${style.surface} ${style.sourceCanvas}`}
+                style={{
+                  background: "hotpink",
+                  position: "absolute",
+                  left: 0,
+                  right: 0,
+                  top: 0,
+                  bottom: 0
+                }}
+              >
+                I'm a "Canvas"
+              </div>
+            </ElementCache>
+          ) : null}
+        </div>
+      </React.Fragment>
+    );
+  }
 }
 
-export {
-    MyComponent,
-};
+export { MyComponent };

--- a/js/my-component.tsx
+++ b/js/my-component.tsx
@@ -26,10 +26,7 @@ enum CanvasMode {
 interface State {
   showModal: boolean;
   canvasMode: CanvasMode;
-  canvasEl?: HTMLElement;
 }
-
-const CANVAS_ID = "canvasEl";
 
 class MyComponent extends React.Component<Props, State> {
   private fullscreenDiv?: HTMLDivElement;
@@ -43,8 +40,6 @@ class MyComponent extends React.Component<Props, State> {
   }
 
   componentDidMount() {
-    const canvasEl = document.getElementById(CANVAS_ID)!;
-    this.setState({ canvasEl });
     this.registerFscreenCallbacks();
   }
 


### PR DESCRIPTION
As you have noticed yourself, calling `getBoundingClientRect` et al on a rAF-basis is absolutely unacceptable for performance reasons alone.

I assume the reason you ended up here is because you thought you couldn’t re-parent the canvas to wherever it currently belongs because React would create a new canvas element. 

I wrote a small memoization component `ElementCache` that reuses the same rendered elements once rendered. This way you can just re-parent the canvas to wherever it needs to be (and use good ol’ absolute positioning). You can check that the element is being re-used by looking at the background color of the canvas and changing the initial value of `canvasMode`.

Let me know if you have any questions :)

**Warning:** I’m not very good with React, so this might be terribly unidiomatic. But I hope you get the concept!

